### PR TITLE
Prepare release 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,20 @@ elixir:
   - 1.3.2
   - 1.3.3
   - 1.3.4
+  - 1.4.0
+  - 1.4.1
 otp_release:
   - 18.3
   - 19.0
   - 19.1
+  - 19.2
 matrix:
   exclude:
     - otp_release: 19.0
       elixir: 1.2.5
     - otp_release: 19.1
+      elixir: 1.2.5
+    - otp_release: 19.2
       elixir: 1.2.5
 addons:
   postgresql: "9.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- Remove `earmark` as a direct dependency since it is already required by `ex_doc`
+- Remove `earmark` as a direct dependency since it is already required by `ex_doc`.
+- Remove warnings when compiling with Elixir 1.4.
 
 ## 1.0.1 - 2016-10-22
 ### Added
 - New testing environments for Travis CI.
 - The project has now a changelog.
-- Improved documentation
-- Improved README
+- Improved documentation.
+- Improved README.
 
 ## 1.0.0 - 2016-07-30
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 - Remove `earmark` as a direct dependency since it is already required by `ex_doc`.
 - Remove warnings when compiling with Elixir 1.4.
+- Adds contribution guidelines detailed in `CONTRIBUTING.md`.
 
 ## 1.0.1 - 2016-10-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Remove `earmark` as a direct dependency since it is already required by `ex_doc`
+
 ## 1.0.1 - 2016-10-22
 ### Added
 - New testing environments for Travis CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,17 @@
+# How to contribute to _Trans_
+
+## Did you find a bug?
+
+If you want to report a bug in _Trans_ take a look among the open [issues](https://github.com/belaustegui/trans/issues) to see if it has been already reported.
+
+If the bug has been already reported, post a comment and add as much information as you can.  Any relevant information can be helpful for fixing the bug.
+
+If the bug has not been reported yet, [open a new issue](https://github.com/belaustegui/trans/issues/new). Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+## Did you write a patch that fixes a bug?
+
+First of all, thank you very much for contributing :heart:.
+
+If you have written a patch that fixes a bug in _Trans_, open a new pull request with the patch. It is important that the pull request description clearly describes the problem and solution. You can also link to the relevant issue if there is one.
+
+The same process applies for contributions related to _Trans_ documentation.

--- a/mix.exs
+++ b/mix.exs
@@ -41,8 +41,7 @@ defmodule Trans.Mixfile do
     [{:postgrex, "~> 0.11"},
      {:ecto, "~> 2.0"},
      {:poison, "~> 2.1"},
-     {:ex_doc, ">= 0.0.0", only: :dev},
-     {:earmark, ">= 0.0.0", only: :dev}]
+     {:ex_doc, ">= 0.0.0", only: :dev}]
   end
 
   defp package do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Trans.Mixfile do
   use Mix.Project
 
-  @version "1.0.1"
+  @version "1.0.2"
 
   def project do
     [app: :trans,

--- a/mix.exs
+++ b/mix.exs
@@ -12,8 +12,8 @@ defmodule Trans.Mixfile do
      start_permanent: Mix.env == :prod,
      elixirc_paths: elixirc_paths(Mix.env),
      app_list: app_list(Mix.env),
-     package: package,
-     deps: deps,
+     package: package(),
+     deps: deps(),
      # Docs
      name: "Trans",
      docs: [source_ref: "v#{@version}", main: "Trans",
@@ -54,12 +54,12 @@ defmodule Trans.Mixfile do
 
   # Include Ecto and Postgrex applications in tests
   def app_list(:test), do: [:ecto, :postgrex]
-  def app_list(_), do: app_list
+  def app_list(_), do: app_list()
   def app_list, do: []
 
   # Always compile files in "lib". In tests compile also files in
   # "test/support"
-  def elixirc_paths(:test), do: elixirc_paths ++ ["test/support"]
-  def elixirc_paths(_), do: elixirc_paths
+  def elixirc_paths(:test), do: elixirc_paths() ++ ["test/support"]
+  def elixirc_paths(_), do: elixirc_paths()
   def elixirc_paths, do: ["lib"]
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,6 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.3", "3d416156e0b7578a31b6925ee07de76b53684ffb4f106b863e35b423b1004b08", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
   "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,9 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
   "db_connection": {:hex, :db_connection, "1.0.0-rc.4", "fad1f772c151cc6bde82412b8d72319968bc7221df8ef7d5e9d7fde7cb5c86b7", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0.0-beta.3", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
+  "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
   "ecto": {:hex, :ecto, "2.0.3", "3d416156e0b7578a31b6925ee07de76b53684ffb4f106b863e35b423b1004b08", [:mix], [{:db_connection, "~> 1.0-rc.2", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.7.7", [hex: :mariaex, optional: true]}, {:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.2", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0-beta", [hex: :sbroker, optional: true]}]},
-  "ex_doc": {:hex, :ex_doc, "0.13.0", "aa2f8fe4c6136a2f7cfc0a7e06805f82530e91df00e2bff4b4362002b43ada65", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
   "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]}}


### PR DESCRIPTION
This release contains:
- #19 Remove warnings with Elixir 1.4
- #7 Review dependencies
- #18 Set guidelines for contributors