### PR TITLE
Make Postgrex an optional dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule Trans.Mixfile do
   #
   # Type "mix help deps" for more examples and options
   defp deps do
-    [{:postgrex, "~> 0.11"},
+    [{:postgrex, "~> 0.11", optional: true},
      {:ecto, "~> 2.0", optional: true},
      {:poison, "~> 2.1"},
      {:ex_doc, ">= 0.0.0", only: :dev}]


### PR DESCRIPTION
The previous PR left the changes unfinished. Now that _Trans_ can be used without a database and _Ecto_ is an optional dependency , _Postgrex_ must be an optional dependency also.

See #11 