### PR TITLE
Remove Ex Machina dependency

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,6 @@ defmodule Trans.Mixfile do
       {:postgrex, "~> 0.11", optional: true},
       {:ecto, "~> 2.1", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev},
-      {:ex_machina, "~> 2.0", only: :test},
       {:faker, "~> 0.7.0", only: :test},
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -4,7 +4,6 @@
   "earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
   "ecto": {:hex, :ecto, "2.1.4", "d1ba932813ec0e0d9db481ef2c17777f1cefb11fc90fa7c142ff354972dfba7e", [:mix], [{:db_connection, "~> 1.1", [hex: :db_connection, optional: true]}, {:decimal, "~> 1.2", [hex: :decimal, optional: false]}, {:mariaex, "~> 0.8.0", [hex: :mariaex, optional: true]}, {:poison, "~> 2.2 or ~> 3.0", [hex: :poison, optional: true]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13.0", [hex: :postgrex, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "ex_machina": {:hex, :ex_machina, "2.0.0", "ec284c6f57233729cea9319e083f66e613e82549f78eccdb2059aeba5d0df9f3", [:mix], [{:ecto, "~> 2.1", [hex: :ecto, optional: true]}]},
   "faker": {:hex, :faker, "0.7.0", "2c42deeac7be717173c78c77fb3edc749fb5d5e460e33d01fe592ae99acc2f0d", [:mix], []},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,9 +1,17 @@
-  alias Trans.Article
+alias Trans.Article
+alias Trans.TestRepo, as: Repo
 
 defmodule Trans.Factory do
-  use ExMachina.Ecto, repo: Trans.TestRepo
 
-  def article_factory do
+  def build(factory, attributes) do
+    factory |> build() |> struct(attributes)
+  end
+
+  def insert(factory, attributes \\ []) do
+    factory |> build(attributes) |> Repo.insert!
+  end
+
+  def build(:article) do
     %Article{
       title: Faker.Lorem.sentence(5, " "),
       body: Faker.Lorem.sentence(10, " "),

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -6,8 +6,6 @@ Mix.Task.run "ecto.migrate", ["quiet", "-r", "Trans.TestRepo"]
 
 # Start TestRepo process
 Trans.TestRepo.start_link
-# Start ExMachina
-{:ok, _} = Application.ensure_all_started(:ex_machina)
 # Run tests
 ExUnit.start()
 


### PR DESCRIPTION
The [Ex Machina](https://hex.pm/packages/ex_machina) dependency has been removed and replaced by a custom but simple factory.