### PR TITLE
Reimplement custom translation containers

### DIFF
--- a/lib/trans/query_builder.ex
+++ b/lib/trans/query_builder.ex
@@ -113,7 +113,7 @@ if Code.ensure_loaded?(Ecto.Query) do
           cond do
             is_nil(field) -> nil
             not Trans.translatable?(unquote(module), unquote(field)) ->
-              raise ArgumentError, message: "'#{inspect(unquote(module))}' module must declare '#{inspect(unquote(field))}' as translatable"
+              raise ArgumentError, message: "'#{inspect(unquote(module))}' module must declare '#{unquote(field)}' as translatable"
             true -> nil
           end
         end

--- a/lib/trans/query_builder.ex
+++ b/lib/trans/query_builder.ex
@@ -75,20 +75,22 @@ if Code.ensure_loaded?(Ecto.Query) do
     """
     defmacro translated(module, translatable, opts) do
       with field <- field(translatable) do
-        Module.eval_quoted(__CALLER__, __validate_fields__(module, field))
-        generate_query(schema(translatable), field, locale(opts))
+        with {module_name, []} <- Module.eval_quoted(__CALLER__, module) do
+          validate_field(module_name, field)
+          generate_query(schema(translatable), module_name, field, locale(opts))
+        end
       end
     end
 
-    defp generate_query(schema, nil, locale) do
+    defp generate_query(schema, module, nil, locale) do
       quote do
-        fragment("(?->?)", field(unquote(schema), :translations), ^unquote(locale))
+        fragment("(?->?)", field(unquote(schema), unquote(module.__trans__(:container))), ^unquote(locale))
       end
     end
 
-    defp generate_query(schema, field, locale) do
+    defp generate_query(schema, module, field, locale) do
       quote do
-        fragment("(?->?->>?)", field(unquote(schema), :translations), ^unquote(locale), ^unquote(field))
+        fragment("(?->?->>?)", field(unquote(schema), unquote(module.__trans__(:container))), ^unquote(locale), ^unquote(field))
       end
     end
 
@@ -106,17 +108,12 @@ if Code.ensure_loaded?(Ecto.Query) do
     defp field({{:., _, [_schema, field]}, _metadata, _args}), do: to_string(field)
     defp field(_), do: nil
 
-    @doc false
-    def __validate_fields__(module, field) do
-      quote do
-        with field <- unquote(field) do
-          cond do
-            is_nil(field) -> nil
-            not Trans.translatable?(unquote(module), unquote(field)) ->
-              raise ArgumentError, message: "'#{inspect(unquote(module))}' module must declare '#{unquote(field)}' as translatable"
-            true -> nil
-          end
-        end
+    defp validate_field(module, field) do
+      cond do
+        is_nil(field) -> nil
+        not Trans.translatable?(module, field) ->
+          raise ArgumentError, message: "'#{inspect(module)}' module must declare '#{field}' as translatable"
+        true -> nil
       end
     end
 

--- a/lib/trans/translator.ex
+++ b/lib/trans/translator.ex
@@ -73,8 +73,8 @@ defmodule Trans.Translator do
     end
   end
 
-  defp translated_field(struct, locale, field) do
-    with {:ok, all_translations}        <- Map.fetch(struct, :translations),
+  defp translated_field(%{__struct__: module} = struct, locale, field) do
+    with {:ok, all_translations}        <- Map.fetch(struct, module.__trans__(:container)),
          {:ok, translations_for_locale} <- Map.fetch(all_translations, to_string(locale)),
          {:ok, translated_field}        <- Map.fetch(translations_for_locale, to_string(field)),
       do: translated_field

--- a/priv/test_repo/migrations/20170402185205_add_comments_table.exs
+++ b/priv/test_repo/migrations/20170402185205_add_comments_table.exs
@@ -1,0 +1,11 @@
+defmodule Trans.TestRepo.Migrations.AddCommentsTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:comments) do
+      add :comment, :string
+      add :article_id, references(:articles)
+      add :transcriptions, :map
+    end
+  end
+end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -1,4 +1,5 @@
 alias Trans.Article
+alias Trans.Comment
 alias Trans.TestRepo, as: Repo
 
 defmodule Trans.Factory do
@@ -15,6 +16,7 @@ defmodule Trans.Factory do
     %Article{
       title: Faker.Lorem.sentence(5, " "),
       body: Faker.Lorem.sentence(10, " "),
+      comments: [build(:comment), build(:comment)],
       translations: %{
         "es" => %{
           "title" => Faker.Lorem.sentence(5, " "),
@@ -24,6 +26,16 @@ defmodule Trans.Factory do
           "title" => Faker.Lorem.sentence(5, " "),
           "body"  => Faker.Lorem.sentence(10, " ")
         }
+      },
+    }
+  end
+
+  def build(:comment) do
+    %Comment{
+      comment: Faker.Lorem.sentence(5, " "),
+      transcriptions: %{
+        "es" => %{"comment" => Faker.Lorem.sentence(5, " ")},
+        "fr" => %{"comment" => Faker.Lorem.sentence(5, " ")},
       }
     }
   end

--- a/test/support/models/article.ex
+++ b/test/support/models/article.ex
@@ -8,9 +8,10 @@ defmodule Trans.Article do
     field :title, :string
     field :body, :string
     field :translations, :map
+    has_many :comments, Trans.Comment
   end
 
-  def changeset(article, params \\ :empty) do
+  def changeset(article, params \\ %{}) do
     article
     |> cast(params, [:title, :body, :translations])
     |> validate_required([:title, :body])

--- a/test/support/models/comment.ex
+++ b/test/support/models/comment.ex
@@ -1,0 +1,18 @@
+defmodule Trans.Comment do
+  use Ecto.Schema
+  use Trans, translates: [:comment], container: :transcriptions
+
+  import Ecto.Changeset
+
+  schema "comments" do
+    field :comment, :string
+    field :transcriptions, :map
+    belongs_to :article, Trans.Article
+  end
+
+  def changeset(comment, params \\ %{}) do
+    comment
+    |> cast(params, [:comment, :transcriptions])
+    |> validate_required([:comment])
+  end
+end

--- a/test/trans_test.exs
+++ b/test/trans_test.exs
@@ -1,4 +1,5 @@
 alias Trans.Article
+alias Trans.Comment
 
 import Trans.Factory
 
@@ -22,6 +23,10 @@ defmodule TransTest do
 
   test "returns the default translation container when unspecified" do
     assert Article.__trans__(:container) == :translations
+  end
+
+  test "returns the custom translation container name if specified" do
+    assert Comment.__trans__(:container) == :transcriptions
   end
 
   test "compilation fails when translation container is not a valid field" do

--- a/test/trans_test.exs
+++ b/test/trans_test.exs
@@ -19,4 +19,22 @@ defmodule TransTest do
       assert Trans.translatable?(article, :fake_field) == false
     end
   end
+
+  test "returns the default translation container when unspecified" do
+    assert Article.__trans__(:container) == :translations
+  end
+
+  test "compilation fails when translation container is not a valid field" do
+    invalid_module = quote do
+      defmodule TestArticle do
+        use Trans, translates: [:title, :body], container: :invalid_container
+        defstruct title: "", body: "", translations: %{}
+      end
+    end
+
+    assert_raise ArgumentError,
+      "The field invalid_container used as the translation container is not defined in Elixir.TestArticle struct",
+      fn -> Code.eval_quoted(invalid_module) end
+  end
+
 end

--- a/test/translator_test.exs
+++ b/test/translator_test.exs
@@ -18,6 +18,11 @@ defmodule TranslatorTest do
     assert body == article.body
   end
 
+  test "use custom translation container if required" do
+    comment = build(:comment)
+    assert Translator.translate(comment, :es, :comment) == comment.transcriptions["es"]["comment"]
+  end
+
   test "raise error wen translating an untraslatable attribute" do
     assert_raise RuntimeError, "'Trans.Article' module must declare ':fake_attr' as translatable", fn ->
       Translator.translate(build(:article), :es, :fake_attr)


### PR DESCRIPTION
For the original details, take a look at issue #33.

This PR reintroduces the possilibity of specifying custom translation containers.

- [x] Allow specifying a custom translation container when using `Trans`
- [x] Generate a `__trans__(:container)` function in the module
- [x] Use the translation container from the `Trans.Translator` module
- [x] Use the translation container from the `Trans.QueryBuilder` module
- [x] Add tests with a custom translation container (see #29)