### PR TITLE
Fix mistake in README example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - Integrate Ebert for code style checks and static analysis.
+- Fix typos and mistakes in README.
 
 ## 2.0.0 - 2017-04-11
 - Rewrite the `Trans` module to use underscore functions to store configuration.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ defmodule MyApp.Repo.Migrations.AddTranslationsToArticles do
   use Ecto.Migration
 
   def change do
-    update table(:articles) do
+    alter table(:articles) do
       add :translations, :map
     end
   end


### PR DESCRIPTION
This PR fixes issue #40 by calling `Ecto.Migration.alter` function.  The `update` function previously used in the example did not exist.

Thanks to @speeddragon for the heads up :+1: 