### PR TITLE
Support Elixir up to 1.5 and OTP up to 20.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,7 @@
 language: elixir
 elixir:
-  - 1.3.2
-  - 1.3.3
   - 1.3.4
-  - 1.4.0
-  - 1.4.1
-  - 1.4.2
-  - 1.5.0
+  - 1.4.5
   - 1.5.1
 otp_release:
   - 18.3
@@ -18,6 +13,13 @@ otp_release:
   - 20.1
 addons:
   postgresql: "9.4"
+matrix:
+  exclude:
+    - elixir: 1.3.4
+      otp_release: 20.0
+    - elixir: 1.3.4
+      otp_release: 20.1
+
 before_script:
   - cp config/test.travis.exs config/test.exs
   - mix deps.get

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,12 @@ otp_release:
   - 19.2
   - 19.3
   - 20.0
-  - 20.1
 addons:
   postgresql: "9.4"
 matrix:
   exclude:
     - elixir: 1.3.4
       otp_release: 20.0
-    - elixir: 1.3.4
-      otp_release: 20.1
 
 before_script:
   - cp config/test.travis.exs config/test.exs

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ elixir:
   - 1.4.0
   - 1.4.1
   - 1.4.2
+  - 1.5.0
+  - 1.5.1
 otp_release:
   - 18.3
   - 19.0
   - 19.1
   - 19.2
   - 19.3
+  - 20.0
+  - 20.1
 addons:
   postgresql: "9.4"
 before_script:


### PR DESCRIPTION
This PR adds support in the testing pipeline for Elixir 1.5.0 and 1.5.1 and Erlang/OTP 20.0 and 20.1